### PR TITLE
Force SSL on the cloudfront url

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
 
       content = [
         '<script ',
-        'src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js" ',
+        'src="https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js" ',
         'data-appversion="' + config.currentRevision + '" ',
         'data-apikey="' + bugsnagConfig.apiKey + '">',
         '</script>',


### PR DESCRIPTION
In our cordova hybrid app if we use the default src="// mapping for the bugsnag JS file it translates it to file:// on iOS which will 404. Forcing the URL to always use SSL fixes this issue.