### PR TITLE
Protect against Bugsnag being blocked by adblockers

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,10 @@ module.exports = {
         'data-apikey="' + bugsnagConfig.apiKey + '">',
         '</script>',
         '<script>',
+        'if (typeof Bugsnag !== "undefined") {',
         'Bugsnag.releaseStage = "' + config.environment + '";',
         'Bugsnag.notifyReleaseStages = ["' + envArray.join('","') + '"];',
+        '}',
         '</script>'
       ];
     }


### PR DESCRIPTION
Ghostery can be set to block Bugsnag, which prevents the app from loading as `Bugsnag` is not defined.