### PR TITLE
Move initializer to instance initializers

### DIFF
--- a/app/instance-initializers/bugsnag.js
+++ b/app/instance-initializers/bugsnag.js
@@ -7,24 +7,24 @@ var currentEnv = config.environment;
 export default {
   name: 'bugsnag-error-service',
 
-  initialize: function(container) {
+  initialize: function(application) {
     if (typeof Bugsnag === 'undefined') { return; }
 
     if (currentEnv !== 'test' && Bugsnag.notifyReleaseStages.indexOf(currentEnv) !== -1) {
       Ember.onerror = function (error) {
-        Bugsnag.context = getContext(container.lookup('router:main'));
+        Bugsnag.context = getContext(application.container.lookup('router:main'));
         Bugsnag.notifyException(error);
         console.error(error.stack);
       };
 
       Ember.RSVP.on('error', function(error) {
-        Bugsnag.context = getContext(container.lookup('router:main'));
+        Bugsnag.context = getContext(application.container.lookup('router:main'));
         Bugsnag.notifyException(error);
         console.error(error.stack);
       });
 
       Ember.Logger.error = function (message, cause, stack) {
-        Bugsnag.context = getContext(container.lookup('router:main'));
+        Bugsnag.context = getContext(application.container.lookup('router:main'));
         Bugsnag.notifyException(generateError(cause, stack), message);
         console.error(stack);
       };


### PR DESCRIPTION
Not ready for merge, just for discussion.

The addon breaks in Ember 2.0 because you can't lookup from the container in application initializers anymore.

Moving to an instance initializer works, but that receives an `application` vs the `container`.

This obviously isn't backwards compatible, so we'll probably need to add back an application initializer and only run that if we're not on Ember 2.0?