### PR TITLE
Refresh Bugsnag's rate limit on each transition

### DIFF
--- a/app/initializers/bugsnag.js
+++ b/app/initializers/bugsnag.js
@@ -28,6 +28,13 @@ export default {
         Bugsnag.notifyException(generateError(cause, stack), message);
         console.error(stack);
       };
+
+      const router = container.lookup('router:main');
+      const originalDidTransition = router.didTransition || Ember.K;
+      router.didTransition = function() {
+        Bugsnag.refresh();
+        return originalDidTransition.apply(this, arguments);
+      };
     }
   }
 };


### PR DESCRIPTION
From https://bugsnag.com/docs/notifiers/js#rate-limiting:

> By default only 10 errors are allowed per page load. This is to prevent wasting a
> user's bandwidth sending thousands of exceptions to Bugsnag. If you have a long-running
> single page app, you can reset this rate-limit from your router by using:
> `Bugsnag.refresh()`