### PR TITLE
Allow overriding the library URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ There are two ways to configure `ember-cli-bugsnag`:
 export BUGSNAG_API_KEY=''
 export BUGSNAG_NOTIFY_RELEASE='development,production'
 ```
+
+Configuration options:
+
+ * `config.bugsnag.apiKey` / `BUGSNAG_API_KEY` -- **required**
+ * `config.bugsnag.notifyReleaseStages` / `BUGSNAG_NOTIFY_RELEASE` -- optional, defaults to `[]` (never notify)
+ * `config.currentRevision` -- any string representing the current version of the app, e.g. `"1b8ef2c7"` or `"v1.2.4"`, optional. [ember-git-version](https://github.com/rwjblue/ember-git-version) provides this automatically.

--- a/README.md
+++ b/README.md
@@ -37,4 +37,5 @@ Configuration options:
  * `config.bugsnag.apiKey` / `BUGSNAG_API_KEY` -- **required**
  * `config.bugsnag.notifyReleaseStages` / `BUGSNAG_NOTIFY_RELEASE` -- optional, defaults to `[]` (never notify)
  * `config.bugsnag.releaseStage` / `BUGSNAG_RELEASE_STAGE` -- optional, defaults to `config.environment`
+ * `config.bugsnag.libraryUrl` / `BUGSNAG_LIBRARY_URL` -- optional, defaults to `'https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js'`. If you want to lock to a particular version of the Bugsnag reporter, you can set this to, e.g. `'//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.4.8.min.js'`. See [Bugsnag: Advanced Hosting](https://bugsnag.com/docs/notifiers/js#advanced-hosting)
  * `config.currentRevision` -- any string representing the current version of the app, e.g. `"1b8ef2c7"` or `"v1.2.4"`, optional. [ember-git-version](https://github.com/rwjblue/ember-git-version) provides this automatically.

--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ Configuration options:
 
  * `config.bugsnag.apiKey` / `BUGSNAG_API_KEY` -- **required**
  * `config.bugsnag.notifyReleaseStages` / `BUGSNAG_NOTIFY_RELEASE` -- optional, defaults to `[]` (never notify)
+ * `config.bugsnag.releaseStage` / `BUGSNAG_RELEASE_STAGE` -- optional, defaults to `config.environment`
  * `config.currentRevision` -- any string representing the current version of the app, e.g. `"1b8ef2c7"` or `"v1.2.4"`, optional. [ember-git-version](https://github.com/rwjblue/ember-git-version) provides this automatically.

--- a/index.js
+++ b/index.js
@@ -24,12 +24,14 @@ module.exports = {
 
         bugsnagConfig = {
           apiKey: envApiKey,
-          notifyReleaseStages: envReleases.split(',')
+          notifyReleaseStages: envReleases.split(','),
+          releaseStage: process.env['BUGSNAG_RELEASE_STAGE']
         };
       } else {
         bugsnagConfig = config.bugsnag;
       }
 
+      var releaseStage = bugsnagConfig.releaseStage || config.environment;
       envArray = bugsnagConfig.notifyReleaseStages ? bugsnagConfig.notifyReleaseStages : [];
 
       content = [
@@ -40,7 +42,7 @@ module.exports = {
         '</script>',
         '<script>',
         'if (typeof Bugsnag !== "undefined") {',
-        'Bugsnag.releaseStage = "' + config.environment + '";',
+        'Bugsnag.releaseStage = "' + releaseStage + '";',
         'Bugsnag.notifyReleaseStages = ["' + envArray.join('","') + '"];',
         '}',
         '</script>'

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
 
         bugsnagConfig = {
           apiKey: envApiKey,
+          libraryUrl: process.env['BUGSNAG_LIBRARY_URL'],
           notifyReleaseStages: envReleases.split(','),
           releaseStage: process.env['BUGSNAG_RELEASE_STAGE']
         };
@@ -31,12 +32,13 @@ module.exports = {
         bugsnagConfig = config.bugsnag;
       }
 
+      var libraryUrl = bugsnagConfig.libraryUrl || 'https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js';
       var releaseStage = bugsnagConfig.releaseStage || config.environment;
       envArray = bugsnagConfig.notifyReleaseStages ? bugsnagConfig.notifyReleaseStages : [];
 
       content = [
         '<script ',
-        'src="https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js" ',
+        'src="' + libraryUrl + '" ',
         'data-appversion="' + config.currentRevision + '" ',
         'data-apikey="' + bugsnagConfig.apiKey + '">',
         '</script>',


### PR DESCRIPTION
This builds on top of #26 to allow the consuming application to specify the bugsnag library URL used.

From https://bugsnag.com/docs/notifiers/js#advanced-hosting

> We will occasionally update bugsnag-2.js on the CDN to improve the quality of our
> notifier without breaking backward compatibility. If you need assurance that the
> javascript will never change, feel free to include the specific version directly.

    <script src="//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.4.8.min.js"
            data-apikey="YOUR-API-KEY-HERE"></script>