### PR TITLE
Add helper for setting error metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,20 @@ Configuration options:
  * `config.bugsnag.releaseStage` / `BUGSNAG_RELEASE_STAGE` -- optional, defaults to `config.environment`
  * `config.bugsnag.libraryUrl` / `BUGSNAG_LIBRARY_URL` -- optional, defaults to `'https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js'`. If you want to lock to a particular version of the Bugsnag reporter, you can set this to, e.g. `'//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.4.8.min.js'`. See [Bugsnag: Advanced Hosting](https://bugsnag.com/docs/notifiers/js#advanced-hosting)
  * `config.currentRevision` -- any string representing the current version of the app, e.g. `"1b8ef2c7"` or `"v1.2.4"`, optional. [ember-git-version](https://github.com/rwjblue/ember-git-version) provides this automatically.
+
+## Customization
+
+In order to add custom meta data to errors reported to Bugsnag, define a
+helper method in `app/utils/bugsnag.js` that takes the error and the container
+as arguments, e.g.:
+
+```js
+export function getMetaData(error, container) {
+  return {
+    // …some meta data
+  };
+}
+```
+
+ember-cli-bugsnag calls this method for every error and resports any data
+returned by it to Bugsnag as meta data for the respective error.

--- a/app/instance-initializers/bugsnag.js
+++ b/app/instance-initializers/bugsnag.js
@@ -1,6 +1,7 @@
 import Ember  from 'ember';
 import config from '../config/environment';
 import { getContext, generateError } from 'ember-cli-bugsnag/utils/errors';
+import { getMetaData } from '../utils/bugsnag';
 
 var currentEnv = config.environment;
 
@@ -16,19 +17,23 @@ export default {
 
       Ember.onerror = function (error) {
         Bugsnag.context = getContext(router);
-        Bugsnag.notifyException(error);
+        const metaData = getMetaData(error, container);
+        Bugsnag.notifyException(error, null, metaData);
         console.error(error.stack);
       };
 
       Ember.RSVP.on('error', function(error) {
         Bugsnag.context = getContext(router);
-        Bugsnag.notifyException(error);
+        const metaData = getMetaData(error, container);
+        Bugsnag.notifyException(error, null, metaData);
         console.error(error.stack);
       });
 
       Ember.Logger.error = function (message, cause, stack) {
         Bugsnag.context = getContext(router);
-        Bugsnag.notifyException(generateError(cause, stack), message);
+        const error = generateError(cause, stack);
+        const metaData = getMetaData(error, container);
+        Bugsnag.notifyException(error, message, metaData);
         console.error(stack);
       };
 

--- a/app/utils/bugsnag.js
+++ b/app/utils/bugsnag.js
@@ -1,0 +1,3 @@
+export function getMetaData(error, container) {
+  return {};
+}


### PR DESCRIPTION
This adds a helper in `app/utils/bugsnag` that allows to add error metadata by simply overriding that in the application, e.g.:

```js
// app/utils/bugsnag.js
export function getMetaData(error, container) {
  return {
    // some meta data from the error or from anywhere
  };
}
```