### PR TITLE
Ignore TransitionAborted errors

### DIFF
--- a/app/instance-initializers/bugsnag.js
+++ b/app/instance-initializers/bugsnag.js
@@ -14,19 +14,21 @@ export default {
       let owner = instance.lookup ? instance : instance.container;
       let router = owner.lookup('router:main');
 
-      Ember.onerror = function (error) {
+      Ember.onerror = function(error) {
         Bugsnag.context = getContext(router);
         Bugsnag.notifyException(error);
         console.error(error.stack);
       };
 
       Ember.RSVP.on('error', function(error) {
-        Bugsnag.context = getContext(router);
-        Bugsnag.notifyException(error);
-        console.error(error.stack);
+        if (error.name !== 'TransitionAborted') {
+          Bugsnag.context = getContext(router);
+          Bugsnag.notifyException(error);
+          console.error(error.stack);
+        }
       });
 
-      Ember.Logger.error = function (message, cause, stack) {
+      Ember.Logger.error = function(message, cause, stack) {
         Bugsnag.context = getContext(router);
         Bugsnag.notifyException(generateError(cause, stack), message);
         console.error(stack);


### PR DESCRIPTION
It seems like TransitionAborted errors are not important for error reporting

https://github.com/emberjs/ember.js/commit/322fc0e371a6df88c1c29d80db8cb545be5315a8

Importantly they also don't have a stack method so they make the addon crash. I should look into whether all RSVP errors also don't have a stack method defined on them.

Fixes #36