### PR TITLE
Remove additional error calls

### DIFF
--- a/app/instance-initializers/bugsnag.js
+++ b/app/instance-initializers/bugsnag.js
@@ -15,26 +15,11 @@ export default {
       let owner = instance.lookup ? instance : instance.container;
       let router = owner.lookup('router:main');
 
-      Ember.onerror = function (error) {
+      Ember.onerror = function(error) {
         Bugsnag.context = getContext(router);
-        const metaData = getMetaData(error, container);
+        const metaData = getMetaData(error, owner);
         Bugsnag.notifyException(error, null, metaData);
         console.error(error.stack);
-      };
-
-      Ember.RSVP.on('error', function(error) {
-        Bugsnag.context = getContext(router);
-        const metaData = getMetaData(error, container);
-        Bugsnag.notifyException(error, null, metaData);
-        console.error(error.stack);
-      });
-
-      Ember.Logger.error = function (message, cause, stack) {
-        Bugsnag.context = getContext(router);
-        const error = generateError(cause, stack);
-        const metaData = getMetaData(error, container);
-        Bugsnag.notifyException(error, message, metaData);
-        console.error(stack);
       };
 
       const originalDidTransition = router.didTransition || Ember.K;


### PR DESCRIPTION
Ember errors are better now, we should be able to catch all types of error from just using Ember.onerror

https://github.com/emberjs/ember.js/blob/322fc0e371a6df88c1c29d80db8cb545be5315a8/packages/ember-runtime/lib/ext/rsvp.js#L59

This was actually causing us to report errors three times each in some cases.

Fixes #36
